### PR TITLE
fix getVoltage function

### DIFF
--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -105,6 +105,7 @@ unsigned long getAnalog() {
 
 unsigned long getVoltage() {
   unsigned long tmp, sum;
+  sum = 0;
   for(byte i=0; i < NB_ANALOG_RD; i++){
     tmp = getAnalog();
     sum = sum + tmp;


### PR DESCRIPTION
fix a bad voltage reading bug if sum var in getVoltage() is not well initialized